### PR TITLE
Detect duplicates by track name and artist - Fixes #12

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -85,10 +85,11 @@
                             <button class="btn btn-primary btn-xs" data-bind="click: removeDuplicates">Remove duplicates from this playlist</button>
                             <ul class="duplicates" data-bind="foreach: duplicates()">
                                 <li>
-                                     <span class="badge">Duplicate</span> <strong><span data-bind="text: track.name">
-                                    </span></strong> by
-                                    <strong><span data-bind="text: track.artists[0].name">
-                                    </span></strong>
+                                    <span class="badge" data-bind="if: reason == 'same-id'">Duplicate</span>
+                                    <span class="badge" data-bind="if: reason == 'same-name-artist'">Duplicate (same name and duration)</span>
+                                    <strong><span data-bind="text: track.name">
+                                    </span></strong> by <strong><span data-bind="text: track.artists[0].name">
+                                    </span>
                                 </li>
                             </ul>
                             <!-- /ko -->


### PR DESCRIPTION
This PR adds duplicate detection based on the same track name and main artist name, as well as a similar track duration.