### PR TITLE
Fix: Song titles with HTML entities do not render correctly #119

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -87,6 +87,12 @@ i18n
     lng: 'en',
     keySeparator: false, // we do not use keys in form messages.welcome
     debug: false,
+    react: {
+      transSupportBasicHtmlNodes: false,
+    },
+    interpolation: {
+      escapeValue: false,
+    },
     missingKeyHandler: (
       lng,
       ns,


### PR DESCRIPTION
Fixes https://github.com/JMPerez/spotify-dedup/issues/119

[HTML entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) such as quotation marks (`&quote;`) and apostrophe (`&#39`) do not render correctly:

Example:
> No More "I Love You's" by Annie Lennox

renders as:
> No More &quote;I Love You&#39s&quote; by Annie Lennox

Before:
<img width="762" alt="before" src="https://user-images.githubusercontent.com/11625008/109044938-4b64b400-76d3-11eb-8ff3-a04a4c5e12ec.png">

Fixed:
<img width="793" alt="after" src="https://user-images.githubusercontent.com/11625008/109044944-4dc70e00-76d3-11eb-897a-a518e69d3af2.png">

Reference: https://github.com/i18next/react-i18next/issues/1205#issuecomment-738676560