### PR TITLE
fix: uncaught errors using custom fetch

### DIFF
--- a/dedup/customFetch.ts
+++ b/dedup/customFetch.ts
@@ -1,102 +1,49 @@
 /**
- * Custom Fetch is a fetcher that queues and retries requests
+ * Custom Fetch is a fetcher that retries requests with exponential delay
  *
- * Every time `customFetch` is called, it queues the request and it
- * gets executed when the previous ones have finalised. It also adds
- * a delay before retrying requests.
+ * This custom fetch has the same interface as native fetch
+ * with three extra options for init param:
+ *  times    - number of attemps    (defaults 3)
+ *  delay    - basic delay in ms    (defaults 1000)
+ *  backoff  - exponential backoff  (defaults 1.3)
  */
 
-type QueuedFetchType = {
-  resolve: any;
-  reject: (error: ErrorType) => void;
-  url: string;
-  options: RequestInit;
-  retries: number;
-};
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-type ErrorType = {
-  message: string;
-  url: string;
-  options: RequestInit;
-};
+export async function retryFetch(
+  input: RequestInfo,
+  init?: RequestInit & { times?: number; delay?: number; backoff?: number }
+) {
+  const times = init?.times || 3;
+  const delay = init?.delay || 1000;
+  const backoff = init?.backoff || 1.3;
 
-const retries = 3;
-const timeoutBetweenFailingRequests = {
-  min: 2000,
-  max: 5000,
-};
-const queue: Array<QueuedFetchType> = [];
-let ongoingFetch = null;
+  for (let attemp = 1; attemp <= times; attemp++) {
+    try {
+      const response = await fetch(input, init);
 
-async function execute(entry: QueuedFetchType) {
-  let shouldRetry = false;
-  try {
-    const response = await fetch(entry.url, entry.options);
-    let success = response.status < 400;
-    if (success) {
-      entry.resolve(response);
-    } else {
-      console.error('Got status ' + response.status, entry);
-      if (--entry.retries > 0) {
-        shouldRetry = true;
-      } else {
-        entry.reject({
-          message: 'Too many retries',
-          url: entry.url,
-          options: entry.options,
-        });
+      if (response.status < 400) {
+        return response;
+      }
+
+      throw new Error('Failed fetch');
+    } catch (error) {
+      console.warn('Fetch attemp failed', attemp);
+
+      if (attemp < times) {
+        await sleep(delay * attemp * backoff);
+        continue;
+      }
+
+      if (attemp === times) {
+        console.warn('Max attemps reached');
+
+        throw error;
       }
     }
-  } catch (e) {
-    if (--entry.retries > 0) {
-      shouldRetry = true;
-    } else {
-      entry.reject({
-        message: e.message,
-        url: entry.url,
-        options: entry.options,
-      });
-    }
-  }
-  if (shouldRetry) {
-    setTimeout(() => {
-      execute(entry);
-    }, timeoutBetweenFailingRequests.min + Math.random() * (timeoutBetweenFailingRequests.max - timeoutBetweenFailingRequests.min));
   }
 }
 
-async function tryToExecute() {
-  if (!ongoingFetch && queue.length > 0) {
-    const next = queue.shift();
-    ongoingFetch = next;
-    execute(next);
-  }
-}
-
-async function customFetch(fetchParams: {
-  url: string;
-  options?: { [key: string]: any };
-}): Promise<any> {
-  const promise = new Promise((resolve, reject) => {
-    queue.push({
-      resolve,
-      reject,
-      url: fetchParams.url,
-      options: fetchParams.options,
-      retries: retries,
-    });
-  });
-
-  // we try to execute a fetch when it gets queued
-  tryToExecute();
-
-  promise.then(() => {
-    ongoingFetch = null;
-    // we try to execute a fetch when a previous fetch has finalised
-    tryToExecute();
-  });
-
-  return promise;
-}
-
-export default customFetch;
+export default retryFetch;

--- a/dedup/spotifyApi.ts
+++ b/dedup/spotifyApi.ts
@@ -120,13 +120,10 @@ export default class SpotifyWebApi {
             .join('&')}`;
 
     try {
-      const res = await fetch({
-        url: `${url}${optionsString}`,
-        options: {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${this.token}`,
-          },
+      const res = await fetch(`${url}${optionsString}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.token}`,
         },
       });
       return parseAPIResponse(res);
@@ -153,18 +150,18 @@ export default class SpotifyWebApi {
       tracks: uris.map((uri) => (typeof uri === 'string' ? { uri: uri } : uri)),
     };
 
-    const res = await fetch({
-      url: `${apiPrefix}/users/${encodeURIComponent(
+    const res = await fetch(
+      `${apiPrefix}/users/${encodeURIComponent(
         userId
       )}/playlists/${playlistId}/tracks`,
-      options: {
+      {
         method: 'DELETE',
         headers: {
           Authorization: `Bearer ${this.token}`,
         },
         body: JSON.stringify(dataToBeSent),
-      },
-    });
+      }
+    );
     return parseAPIResponse(res);
   }
 
@@ -173,15 +170,12 @@ export default class SpotifyWebApi {
   }
 
   async removeFromMySavedTracks(trackIds: Array<string>) {
-    const res = await fetch({
-      url: `${apiPrefix}/me/tracks`,
-      options: {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${this.token}`,
-        },
-        body: JSON.stringify(trackIds),
+    const res = await fetch(`${apiPrefix}/me/tracks`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
       },
+      body: JSON.stringify(trackIds),
     });
     return parseAPIResponse(res);
   }


### PR DESCRIPTION
This PR:

1. Simplifies custom fetch code.
2. Makes custom fetch interface closer to native browser fetch - just adds 3 more optional fields (`times`, `delay`, `backoff`) to the second param.
3. Fixes issue with freezing app and Uncaught exception. More details - below.

With the existing implementation of fetch if any external API error occurs - the app will throw an uncaught exception (despite `catch` sections) and will freeze.
To reproduce - load app, login, wait for playlists scan, disable network, and click `Remove duplicates...` button. After 3 retries app will throw an uncaught exception and the `Remove duplicates...` button will not respond anymore when the network will back to normal.

![image](https://user-images.githubusercontent.com/16646570/113819773-72a6aa80-9782-11eb-879b-176951a400b8.png)
