### PR TITLE
Compare all artists when doing dedup, not just primary

### DIFF
--- a/components/main.tsx
+++ b/components/main.tsx
@@ -222,7 +222,7 @@ export default class Main extends React.Component<{
                               key={index}
                               reason={duplicate.reason}
                               trackName={duplicate.track.name}
-                              trackArtistName={duplicate.track.artists[0].name}
+                              trackArtistName={duplicate.track.artists.map(artist => artist.name).join(", ")}
                             />
                           )
                         )}
@@ -278,7 +278,7 @@ export default class Main extends React.Component<{
                               key={index}
                               reason={duplicate.reason}
                               trackName={duplicate.track.name}
-                              trackArtistName={duplicate.track.artists[0].name}
+                              trackArtistName={duplicate.track.artists.map(artist => artist.name).join(", ")}
                             />
                           ))}
                         </DuplicateTrackList>

--- a/dedup/deduplicator.ts
+++ b/dedup/deduplicator.ts
@@ -21,13 +21,13 @@ class BaseDeduplicator {
       if (track.id === null) return duplicates;
       let reasonDuplicate: 'same-id' | 'same-name-artist' | null = null;
       const seenNameAndArtistKey =
-        `${track.name}:${track.artists[0].name}`.toLowerCase();
+        `${track.name}:${track.artists.map(artist => artist.name).join(",")}`.toLowerCase();
       if (track.id in seenIds) {
         // if the two tracks have the same Spotify ID, they are duplicates
         reasonDuplicate = 'same-id';
       } else {
-        // if they have the same name, main artist, and roughly same duration
-        // we consider tem duplicates too
+        // if they have the same name, all artists, and roughly same duration
+        // we consider them duplicates too
         if (seenNameAndArtistKey in seenNameAndArtist) {
           // we check if _any_ of the previous durations is similar to the one we are checking
           if (


### PR DESCRIPTION
Fixes #160.

Now compares the full list of artists when deciding if tracks with different IDs are duplicates.

Also displays the full list of artists for duplicate songs after processing.

I also noticed the "Remove duplicates from this playlist" button moved. Looked this way before my changes. Wasn't sure if it was intentional so I left it as is. If not, that should be a new issue.
<img width="829" height="430" alt="Screenshot 2025-10-22 at 11 29 51 AM" src="https://github.com/user-attachments/assets/8ea9312b-1fba-4b66-90d7-6c4ffffcd739" />
