### PR TITLE
Make `bug_report.md` semantic, and quicker to use.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,52 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report, to help us improve.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+#### What The Bug Is
 
-**To Reproduce**
+<!-- A clear and concise description of what the bug is. -->
+
+#### How To Reproduce It
+
+<!--
+
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+-->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+1. 
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+#### Expected Behavior
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Additional context**
-Add any other context about the problem here.
+#### Relevant Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+#### The Affected Environment
+
+ - #### The Device
+
+   <!-- Example: Surface Laptop -->
+
+ - #### The OS
+
+   <!-- Example: Fedora 43 -->
+
+ - #### The Browser Version
+
+   <!-- Example: Firefox 120 -->
+
+#### Additional Context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
Updates the GHFM BR template to:

- …be CommonMark (and, therefore, inherently WHATWG HTML5 LS / WCAG AA) semantic.

- …include examples that can't accidentally be left in if the reporter forgets to remove them from the template.